### PR TITLE
Fixing calls to faker.Generator

### DIFF
--- a/src/factories.py
+++ b/src/factories.py
@@ -18,7 +18,7 @@ class Cat(SQLAlchemyModelFactory):
     FACTORY_FOR = models.Cat
     FACTORY_SESSION = db.session
 
-    id = factory.LazyAttribute(lambda x: faker.unixTime())
-    born_at = factory.LazyAttribute(lambda x: faker.unixTime())
+    id = factory.LazyAttribute(lambda x: faker.unix_time())
+    born_at = factory.LazyAttribute(lambda x: faker.unix_time())
 
-    name = factory.LazyAttribute(lambda x: faker.firstName())
+    name = factory.LazyAttribute(lambda x: faker.first_name())


### PR DESCRIPTION
Replacing camelCase with under_scores

The targets `make test` `make dummy` didn't work for me. Looks like faker was updated at some point since this code was written, so I just changed the signature of these calls.

Tests:
  Now all the build targets are working for me.
